### PR TITLE
[Feature] Responsive landscape layout for FullPlayer + improved cinematic mode

### DIFF
--- a/.github/workflows/Lune_Build.yml
+++ b/.github/workflows/Lune_Build.yml
@@ -40,7 +40,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build APK
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleDebug
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/Lune_Build.yml
+++ b/.github/workflows/Lune_Build.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: Lune ${{ steps.version.outputs.version }}
-          files: app/build/outputs/apk/release/*apk
+          files: app/build/outputs/apk/debug/*apk

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2773,18 +2773,6 @@ fun FullPlayer(
                         )
                     )
             )
-        } else if (isDarkTheme) {
-            // Classic Dark Background (Blurred Image)
-            AsyncImage(
-                model = song.coverUrl ?: song.albumArtUri,
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .blur(80.dp)
-                    .alpha(0.2f),
-                contentScale = ContentScale.Crop
-            )
-        }
 
         } else if (isDarkTheme) {
             // Classic Dark Background (Blurred Image)
@@ -3365,13 +3353,6 @@ fun FullPlayer(
                 coverContent()
                 controlsContent()
             }
-        }
-
-        if (showQueueSheet) {
-            QueueBottomSheet(
-                playbackManager = playbackManager,
-                onDismiss = { showQueueSheet = false }
-            )
         }
 
         if (showQueueSheet) {

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2772,7 +2772,7 @@ fun FullPlayer(
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxSize()
-                    .alpha(0.08f),
+                    .alpha(0.02f),
                 contentScale = ContentScale.Crop
             )
         }

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2730,15 +2730,14 @@ fun FullPlayer(
             .background(MaterialTheme.colorScheme.surface) // Opaque base
     ) {
         if (isCinematic) {
-            // Cinematic Background (Ken Burns + Gradient)
+            // Apple Music style: full-screen blurred album art + dark scrim + bottom gradient
             AsyncImage(
                 model = song.coverUrl ?: song.albumArtUri,
                 contentDescription = null,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight(0.6f)
-                    .align(Alignment.TopCenter)
+                    .fillMaxSize()              // ← Full screen
                     .clipToBounds()
+                    .blur(48.dp)               // ← Soft blur across the entire screen
                     .graphicsLayer {
                         val baseScale = scale - 1f
                         val maxTransX = (size.width * baseScale) / 2f
@@ -2752,24 +2751,23 @@ fun FullPlayer(
                     },
                 contentScale = ContentScale.Crop
             )
-    
-            val surf = MaterialTheme.colorScheme.surface
-            val mAlpha = if (isDarkTheme) 0.6f else 0.3f
+            // Solid dark background: adds contrast to the cover and text
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.40f))
+            )
+            // Gradient only on the bottom half for the controls
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(
                         Brush.verticalGradient(
-                            0.00f to Color.Transparent,
-                            0.10f to Color.Transparent,
-                            0.25f to surf.copy(alpha = mAlpha * 0.2f),
-                            0.35f to surf.copy(alpha = mAlpha * 0.5f),
-                            0.42f to surf.copy(alpha = mAlpha * 0.85f),
-                            0.48f to surf.copy(alpha = mAlpha + (1f - mAlpha) * 0.4f),
-                            0.52f to surf.copy(alpha = mAlpha + (1f - mAlpha) * 0.75f),
-                            0.56f to surf.copy(alpha = mAlpha + (1f - mAlpha) * 0.9f),
-                            0.60f to surf,
-                            1.00f to surf
+                            0.0f to Color.Transparent,
+                            0.50f to Color.Transparent,
+                            0.72f to Color.Black.copy(alpha = 0.35f),
+                            0.88f to Color.Black.copy(alpha = 0.65f),
+                            1.0f to Color.Black.copy(alpha = 0.80f)
                         )
                     )
             )

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2804,7 +2804,6 @@ fun FullPlayer(
                             totalDragY += dragAmount.y
                             val absY = kotlin.math.abs(totalDragY)
                             val absX = kotlin.math.abs(dragAmount.x)
-                            // Vertical swipe downward only → minimize
                             if (absY > 60 && absY > absX * 1.5f && totalDragY > 0) {
                                 onMinimize()
                                 gestureConsumed = true
@@ -2813,104 +2812,79 @@ fun FullPlayer(
                     }
                 )
             }
-            .padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp)
+            .then(
+                if (isLandscape)
+                    Modifier.padding(top = 16.dp, bottom = 8.dp, start = 24.dp, end = 24.dp)
+                else
+                    Modifier.padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp)
+            )
     
         val coverContent: @Composable () -> Unit = {
-            if (isCinematic) {
-                // Header Spacer
-                Spacer(modifier = Modifier.height(16.dp))
-                
-                // Cinematic layout filler
-                Box(
-                    modifier = Modifier
-                        .aspectRatio(1f)
-                        .fillMaxWidth()
-                        .scale(coverScale)
-                        .pointerInput(Unit) {
-                            var totalDragX = 0f
-                            var gestureConsumed = false
-                            detectDragGestures(
-                                onDragStart = {
-                                    totalDragX = 0f
-                                    gestureConsumed = false
-                                },
-                                onDrag = { _, dragAmount ->
-                                    if (!gestureConsumed) {
-                                        totalDragX += dragAmount.x
-                                        val absX = kotlin.math.abs(totalDragX)
-                                        val absY = kotlin.math.abs(dragAmount.y)
-                                        // Horizontal swipe only (covers next/previous)
-                                        if (absX > 60 && absX > absY * 1.5f) {
-                                            if (totalDragX < 0) onNext() else onPrevious()
-                                            gestureConsumed = true
-                                        }
+            // El Box de la portada es el mismo en cinemático y clásico.
+            // En cinemático la imagen de fondo ya está en la capa de fondo (Background Layer),
+            // así que la portada "real" aquí siempre se muestra.
+            Spacer(modifier = Modifier.height(if (isLandscape) 0.dp else 16.dp))
+        
+            Box(
+                modifier = Modifier
+                    .then(
+                        if (isLandscape)
+                            // En landscape limitamos la altura para que no ocupe toda la pantalla
+                            Modifier.fillMaxHeight(0.80f).aspectRatio(1f)
+                        else
+                            // En portrait ocupamos el ancho disponible
+                            Modifier.fillMaxWidth().aspectRatio(1f)
+                    )
+                    .scale(coverScale)
+                    .pointerInput(Unit) {
+                        var totalDragX = 0f
+                        var gestureConsumed = false
+                        detectDragGestures(
+                            onDragStart = {
+                                totalDragX = 0f
+                                gestureConsumed = false
+                            },
+                            onDrag = { _, dragAmount ->
+                                if (!gestureConsumed) {
+                                    totalDragX += dragAmount.x
+                                    val absX = kotlin.math.abs(totalDragX)
+                                    val absY = kotlin.math.abs(dragAmount.y)
+                                    if (absX > 60 && absX > absY * 1.5f) {
+                                        if (totalDragX < 0) onNext() else onPrevious()
+                                        gestureConsumed = true
                                     }
                                 }
-                            )
-                        },
-    
-                )
-            } else {
-                // Classic Header Spacer
-                Spacer(modifier = Modifier.height(16.dp))
-    
-                // Classic Cover Art
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(1f)
-                        .scale(coverScale)
-                        .pointerInput(Unit) {
-                            var totalDragX = 0f
-                            var gestureConsumed = false
-                            detectDragGestures(
-                                onDragStart = {
-                                    totalDragX = 0f
-                                    gestureConsumed = false
-                                },
-                                onDrag = { _, dragAmount ->
-                                    if (!gestureConsumed) {
-                                        totalDragX += dragAmount.x
-                                        val absX = kotlin.math.abs(totalDragX)
-                                        val absY = kotlin.math.abs(dragAmount.y)
-                                        // Horizontal swipe only (covers next/previous)
-                                        if (absX > 60 && absX > absY * 1.5f) {
-                                            if (totalDragX < 0) onNext() else onPrevious()
-                                            gestureConsumed = true
-                                        }
-                                    }
-                                }
-                            )
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (coverShape == 2 && coverVinylEffect) {
-                        VinylRecordAsyncCover(
-                            model = song.coverUrl ?: song.albumArtUri,
-                            rotation = if (coverSpin && isPlaying) spinRotation else 0f,
-                            modifier = Modifier.fillMaxSize()
+                            }
                         )
-                    } else {
-                        val activeShape = when (coverShape) {
-                            1 -> RoundedCornerShape(0.dp)
-                            2 -> CircleShape
-                            else -> RoundedCornerShape(28.dp)
-                        }
-                        Surface(
-                            shape = activeShape,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .rotate(if (coverShape == 2 && coverSpin && isPlaying) spinRotation else 0f),
-                            color = MaterialTheme.colorScheme.secondaryContainer,
-                            tonalElevation = 8.dp
-                        ) {
-                            AsyncImage(
-                                model = song.coverUrl ?: song.albumArtUri,
-                                contentDescription = null,
-                                modifier = Modifier.fillMaxSize(),
-                                contentScale = ContentScale.Crop
-                            )
-                        }
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                if (coverShape == 2 && coverVinylEffect) {
+                    VinylRecordAsyncCover(
+                        model = song.coverUrl ?: song.albumArtUri,
+                        rotation = if (coverSpin && isPlaying) spinRotation else 0f,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    val activeShape = when (coverShape) {
+                        1 -> RoundedCornerShape(0.dp)
+                        2 -> CircleShape
+                        else -> RoundedCornerShape(28.dp)
+                    }
+                    Surface(
+                        shape = activeShape,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .rotate(if (coverShape == 2 && coverSpin && isPlaying) spinRotation else 0f),
+                        color = MaterialTheme.colorScheme.secondaryContainer,
+                        tonalElevation = 8.dp
+                    ) {
+                        AsyncImage(
+                            model = song.coverUrl ?: song.albumArtUri,
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2751,12 +2751,6 @@ fun FullPlayer(
                     },
                 contentScale = ContentScale.Crop
             )
-            // Solid dark background: adds contrast to the cover and text
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.40f))
-            )
             // Gradient only on the bottom half for the controls
             Box(
                 modifier = Modifier
@@ -2779,7 +2773,7 @@ fun FullPlayer(
                 modifier = Modifier
                     .fillMaxSize()
                     .blur(80.dp)
-                    .alpha(0.2f),
+                    .alpha(0.6f),
                 contentScale = ContentScale.Crop
             )
         }

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2737,7 +2737,7 @@ fun FullPlayer(
                 modifier = Modifier
                     .fillMaxSize()              // ← Full screen
                     .clipToBounds()
-                    .blur(48.dp)               // ← Soft blur across the entire screen
+                    .blur(20.dp)               // ← Soft blur across the entire screen
                     .graphicsLayer {
                         val baseScale = scale - 1f
                         val maxTransX = (size.width * baseScale) / 2f
@@ -2766,14 +2766,13 @@ fun FullPlayer(
                     )
             )
         } else if (isDarkTheme) {
-            // Classic Dark Background (Blurred Image)
+            // Normal dark: subtle ambient glow without blur
             AsyncImage(
                 model = song.coverUrl ?: song.albumArtUri,
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxSize()
-                    .blur(80.dp)
-                    .alpha(0.6f),
+                    .alpha(0.08f),
                 contentScale = ContentScale.Crop
             )
         }

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2639,7 +2639,7 @@ fun FullPlayer(
             }
         }
     }
-
+    
     val playbackManager = remember { PlaybackManager.getInstance(context) }
     val sheetPeekHeight = 0.dp
     val sheetFullHeight = 0.dp
@@ -2661,7 +2661,7 @@ fun FullPlayer(
     val peekHeightPx = with(density) { sheetPeekHeight.toPx() }
     val fullHeightPx = with(density) { sheetFullHeight.toPx() }
     
-
+    
     val infiniteTransition = rememberInfiniteTransition(label = "CoverAnimation")
     val scale by infiniteTransition.animateFloat(
         initialValue = 1.2f,
@@ -2690,7 +2690,7 @@ fun FullPlayer(
         ),
         label = "OffsetY"
     )
-
+    
     var focalPoint by remember { mutableStateOf(Offset(0.5f, 0.5f)) }
     
     LaunchedEffect(song.id) {
@@ -2705,14 +2705,14 @@ fun FullPlayer(
             focalPoint = ImageAnalyzer.findFocalPoint(bitmap)
         }
     }
-
+    
     val isSystemDark = isSystemInDarkTheme()
     val isDarkTheme = when (settingsManager.themeMode) {
         1 -> false
         2 -> true
         else -> isSystemDark
     }
-
+    
     val infiniteSpinTransition = rememberInfiniteTransition(label = "PlayerCoverSpin")
     val spinRotation by infiniteSpinTransition.animateFloat(
         initialValue = 0f,
@@ -2723,7 +2723,7 @@ fun FullPlayer(
         ),
         label = "SpinAnimation"
     )
-
+    
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -2752,7 +2752,7 @@ fun FullPlayer(
                     },
                 contentScale = ContentScale.Crop
             )
-
+    
             val surf = MaterialTheme.colorScheme.surface
             val mAlpha = if (isDarkTheme) 0.6f else 0.3f
             Box(
@@ -2773,7 +2773,6 @@ fun FullPlayer(
                         )
                     )
             )
-
         } else if (isDarkTheme) {
             // Classic Dark Background (Blurred Image)
             AsyncImage(
@@ -2786,10 +2785,10 @@ fun FullPlayer(
                 contentScale = ContentScale.Crop
             )
         }
-
+    
         val configuration = androidx.compose.ui.platform.LocalConfiguration.current
         val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-
+    
         val swipeToMinimizeModifier = Modifier
             .fillMaxSize()
             .pointerInput(Unit) {
@@ -2815,7 +2814,7 @@ fun FullPlayer(
                 )
             }
             .padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp)
-
+    
         val coverContent: @Composable () -> Unit = {
             if (isCinematic) {
                 // Header Spacer
@@ -2849,12 +2848,12 @@ fun FullPlayer(
                                 }
                             )
                         },
-   
+    
                 )
             } else {
                 // Classic Header Spacer
                 Spacer(modifier = Modifier.height(16.dp))
-
+    
                 // Classic Cover Art
                 Box(
                     modifier = Modifier
@@ -2916,7 +2915,7 @@ fun FullPlayer(
                 }
             }
         }
-
+    
         val controlsContent: @Composable () -> Unit = {
             val playbackManagerInstance = PlaybackManager.getInstance(LocalContext.current)
             
@@ -2939,9 +2938,9 @@ fun FullPlayer(
                         color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.fillMaxWidth().basicMarquee()
                     )
-
+    
                     Spacer(modifier = Modifier.height(8.dp))
-
+    
                     // Píldora de Artista Alineada a la Izquierda
                     Surface(
                         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
@@ -2959,7 +2958,7 @@ fun FullPlayer(
                         )
                     }
                 }
-
+    
                 // Botón de Favorito a la derecha con animación Surface
                 val surfaceColor = MaterialTheme.colorScheme.surface
                 val luma = surfaceColor.red * 0.299f + surfaceColor.green * 0.587f + surfaceColor.blue * 0.114f
@@ -2974,7 +2973,7 @@ fun FullPlayer(
                 } else {
                     MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                 }
-
+    
                 Surface(
                     onClick = { 
                         playbackManagerInstance.toggleFavorite {
@@ -2997,9 +2996,9 @@ fun FullPlayer(
                     }
                 }
             }
-
+    
             Column {
-
+    
                 Box(
                     modifier = Modifier.fillMaxWidth(),
                     contentAlignment = Alignment.Center
@@ -3024,7 +3023,7 @@ fun FullPlayer(
                         ),
                         label = "thumbRotation"
                     )
-
+    
                     Slider(
                         value = progress,
                         onValueChange = onProgressChange,
@@ -3045,7 +3044,7 @@ fun FullPlayer(
                         )
                     )
                 }
-
+    
                 // Tiempos separados en píldoras individuales abajo de la barra
                 Row(
                     modifier = Modifier
@@ -3068,7 +3067,7 @@ fun FullPlayer(
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
                         )
                     }
-
+    
                     // Píldora Tiempo Total (Derecha)
                     Surface(
                         color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
@@ -3084,7 +3083,7 @@ fun FullPlayer(
                     }
                 }
             }
-
+    
             val activePrimary = getControlsPrimaryColor(useCustomControlsColor, controlsColorPalette)
             val activeContainerColor = if (useCustomControlsColor) {
                 activePrimary.copy(alpha = 0.2f)
@@ -3096,7 +3095,7 @@ fun FullPlayer(
             } else {
                 MaterialTheme.colorScheme.onSurface
             }
-
+    
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
@@ -3118,7 +3117,7 @@ fun FullPlayer(
                         )
                     }
                 }
-
+    
                 @OptIn(ExperimentalAnimationGraphicsApi::class)
                 Surface(
                     onClick = onTogglePlay,
@@ -3136,7 +3135,7 @@ fun FullPlayer(
                         )
                     }
                 }
-
+    
                 Surface(
                     onClick = onNext,
                     shape = CircleShape,
@@ -3154,9 +3153,9 @@ fun FullPlayer(
                     }
                 }
             }
-
+    
             Spacer(modifier = Modifier.width(16.dp))
-
+    
             androidx.compose.animation.AnimatedContent(
                 targetState = showVolumeBar,
                 transitionSpec = {
@@ -3171,7 +3170,7 @@ fun FullPlayer(
                     LaunchedEffect(playbackManagerInstance.currentVolumePercent) {
                         sliderValue = playbackManagerInstance.currentVolumePercent
                     }
-
+    
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -3253,7 +3252,7 @@ fun FullPlayer(
                                     shape = RoundedCornerShape(topStart = 28.dp, bottomStart = 28.dp, topEnd = 4.dp, bottomEnd = 4.dp),
                                     modifier = Modifier.weight(1f)
                                 )
-
+    
                                 // Queue Button
                                 PlayerActionButton(
                                     icon = Icons.Default.QueueMusic,
@@ -3262,7 +3261,7 @@ fun FullPlayer(
                                     shape = RoundedCornerShape(4.dp),
                                     modifier = Modifier.weight(1f)
                                 )
-
+    
                                 // Share Button
                                 val activityContext = LocalContext.current
                                 PlayerActionButton(
@@ -3307,7 +3306,7 @@ fun FullPlayer(
             }
             
             Spacer(modifier = Modifier.height(8.dp))
-
+    
             if (showWaveform) {
                 WaveformVisualizer(
                     modifier = Modifier
@@ -3319,7 +3318,7 @@ fun FullPlayer(
                 )
             }
         }
-
+    
         if (isLandscape) {
             Row(
                 modifier = swipeToMinimizeModifier,
@@ -3354,16 +3353,14 @@ fun FullPlayer(
                 controlsContent()
             }
         }
-
+    
         if (showQueueSheet) {
             QueueBottomSheet(
                 playbackManager = playbackManager,
                 onDismiss = { showQueueSheet = false }
             )
         }
-
-
-
+    
         if (showOptionsSheet) {
             PlayerOptionsBottomSheet(
                 playbackManager = playbackManager,
@@ -3386,7 +3383,7 @@ fun FullPlayer(
                 }
             )
         }
-
+    
         if (showAddToPlaylistInPlayer) {
             val currentSong = playbackManager.currentSong
             if (currentSong != null) {
@@ -3406,7 +3403,7 @@ fun FullPlayer(
                 )
             }
         }
-
+    
         if (showVisualizerSettings) {
             VisualizerSettingsBottomSheet(
                 playbackManager = playbackManager,

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2811,9 +2811,9 @@ fun FullPlayer(
             )
     
         val coverContent: @Composable () -> Unit = {
-            // El Box de la portada es el mismo en cinemático y clásico.
-            // En cinemático la imagen de fondo ya está en la capa de fondo (Background Layer),
-            // así que la portada "real" aquí siempre se muestra.
+            // The cover art box is the same in both cinematic and classic modes.
+            // In cinematic, the background image is already rendered in the background layer,
+            // so the "real" cover art is always shown here on top.
             Spacer(modifier = Modifier.height(if (isLandscape) 0.dp else 16.dp))
         
             Box(
@@ -2893,7 +2893,7 @@ fun FullPlayer(
                     modifier = Modifier.weight(1f).padding(end = 12.dp),
                     horizontalAlignment = Alignment.Start
                 ) {
-                    // Título Arriba
+                    // Song title
                     Text(
                         song.title,
                         style = MaterialTheme.typography.titleLarge,
@@ -2906,7 +2906,7 @@ fun FullPlayer(
     
                     Spacer(modifier = Modifier.height(8.dp))
     
-                    // Píldora de Artista Alineada a la Izquierda
+                    // Artist pill aligned to the left
                     Surface(
                         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f),
                         shape = RoundedCornerShape(percent = 50),
@@ -2924,7 +2924,7 @@ fun FullPlayer(
                     }
                 }
     
-                // Botón de Favorito a la derecha con animación Surface
+                // Favorite button on the right with animated Surface
                 val surfaceColor = MaterialTheme.colorScheme.surface
                 val luma = surfaceColor.red * 0.299f + surfaceColor.green * 0.587f + surfaceColor.blue * 0.114f
                 val isDark = luma < 0.5f
@@ -3010,7 +3010,7 @@ fun FullPlayer(
                     )
                 }
     
-                // Tiempos separados en píldoras individuales abajo de la barra
+                // Time labels displayed as individual pills below the progress bar
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -3019,7 +3019,7 @@ fun FullPlayer(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    // Píldora Tiempo Actual (Izquierda)
+                    // Current time pill (left)
                     Surface(
                         color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
                         shape = RoundedCornerShape(percent = 50)
@@ -3033,7 +3033,7 @@ fun FullPlayer(
                         )
                     }
     
-                    // Píldora Tiempo Total (Derecha)
+                    // Total time pill (right)
                     Surface(
                         color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
                         shape = RoundedCornerShape(percent = 50)
@@ -3387,7 +3387,7 @@ fun PlayerActionButton(
     shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(16.dp),
     modifier: Modifier = Modifier
 ) {
-    // Detectamos si el esquema de la interfaz está en modo oscuro calculando la luminancia del color de fondo (Surface)
+    // Detect dark mode by calculating the luminance of the Surface background color
     val surfaceColor = MaterialTheme.colorScheme.surface
     val luma = surfaceColor.red * 0.299f + surfaceColor.green * 0.587f + surfaceColor.blue * 0.114f
     val isDark = luma < 0.5f

--- a/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt
@@ -2786,35 +2786,49 @@ fun FullPlayer(
             )
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .pointerInput(Unit) {
-                    var totalDragY = 0f
-                    var gestureConsumed = false
-                    detectDragGestures(
-                        onDragStart = {
-                            totalDragY = 0f
-                            gestureConsumed = false
-                        },
-                        onDrag = { _, dragAmount ->
-                            if (!gestureConsumed) {
-                                totalDragY += dragAmount.y
-                                val absY = kotlin.math.abs(totalDragY)
-                                val absX = kotlin.math.abs(dragAmount.x)
-                                // Vertical swipe downward only → minimize
-                                if (absY > 60 && absY > absX * 1.5f && totalDragY > 0) {
-                                    onMinimize()
-                                    gestureConsumed = true
-                                }
+        } else if (isDarkTheme) {
+            // Classic Dark Background (Blurred Image)
+            AsyncImage(
+                model = song.coverUrl ?: song.albumArtUri,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .blur(80.dp)
+                    .alpha(0.2f),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+        val isLandscape = configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+
+        val swipeToMinimizeModifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                var totalDragY = 0f
+                var gestureConsumed = false
+                detectDragGestures(
+                    onDragStart = {
+                        totalDragY = 0f
+                        gestureConsumed = false
+                    },
+                    onDrag = { _, dragAmount ->
+                        if (!gestureConsumed) {
+                            totalDragY += dragAmount.y
+                            val absY = kotlin.math.abs(totalDragY)
+                            val absX = kotlin.math.abs(dragAmount.x)
+                            // Vertical swipe downward only → minimize
+                            if (absY > 60 && absY > absX * 1.5f && totalDragY > 0) {
+                                onMinimize()
+                                gestureConsumed = true
                             }
                         }
-                    )
-                }
-                .padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.SpaceBetween
-        ) {
+                    }
+                )
+            }
+            .padding(top = 48.dp, bottom = 24.dp, start = 24.dp, end = 24.dp)
+
+        val coverContent: @Composable () -> Unit = {
             if (isCinematic) {
                 // Header Spacer
                 Spacer(modifier = Modifier.height(16.dp))
@@ -2913,8 +2927,10 @@ fun FullPlayer(
                     }
                 }
             }
+        }
 
-            val playbackManager = PlaybackManager.getInstance(LocalContext.current)
+        val controlsContent: @Composable () -> Unit = {
+            val playbackManagerInstance = PlaybackManager.getInstance(LocalContext.current)
             
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
@@ -2973,8 +2989,8 @@ fun FullPlayer(
 
                 Surface(
                     onClick = { 
-                        playbackManager.toggleFavorite {
-                            playbackManager.currentSong?.let { song ->
+                        playbackManagerInstance.toggleFavorite {
+                            playbackManagerInstance.currentSong?.let { song ->
                                 onSyncFavorite?.invoke(song.id, song.isFavorite)
                             }
                         }
@@ -3010,8 +3026,8 @@ fun FullPlayer(
                         amplitude = { 1f }
                     )
                     
-                    val infiniteTransition = rememberInfiniteTransition(label = "thumbRotation")
-                    val rotation by infiniteTransition.animateFloat(
+                    val thumbInfiniteTransition = rememberInfiniteTransition(label = "thumbRotation")
+                    val rotation by thumbInfiniteTransition.animateFloat(
                         initialValue = 0f,
                         targetValue = 360f,
                         animationSpec = infiniteRepeatable(
@@ -3161,11 +3177,11 @@ fun FullPlayer(
                 label = "VolumeBarTransition"
             ) { isVolumeVisible ->
                 if (isVolumeVisible) {
-                    var sliderValue by remember { mutableStateOf(playbackManager.currentVolumePercent) }
+                    var sliderValue by remember { mutableStateOf(playbackManagerInstance.currentVolumePercent) }
                     
                     // Sync local state when manager state changes (e.g. hardware buttons)
-                    LaunchedEffect(playbackManager.currentVolumePercent) {
-                        sliderValue = playbackManager.currentVolumePercent
+                    LaunchedEffect(playbackManagerInstance.currentVolumePercent) {
+                        sliderValue = playbackManagerInstance.currentVolumePercent
                     }
 
                     Row(
@@ -3191,7 +3207,7 @@ fun FullPlayer(
                             value = sliderValue,
                             onValueChange = { 
                                 sliderValue = it
-                                playbackManager.setVolume(it)
+                                playbackManagerInstance.setVolume(it)
                             },
                             thumb = {}, // Remove thumb
                             modifier = Modifier.weight(0.5f),
@@ -3243,8 +3259,8 @@ fun FullPlayer(
                             ) {
                                 // Audio Output Button
                                 PlayerActionButton(
-                                    icon = playbackManager.currentOutputIcon,
-                                    label = playbackManager.currentOutputName,
+                                    icon = playbackManagerInstance.currentOutputIcon,
+                                    label = playbackManagerInstance.currentOutputName,
                                     onClick = { showVolumeBar = true },
                                     shape = RoundedCornerShape(topStart = 28.dp, bottomStart = 28.dp, topEnd = 4.dp, bottomEnd = 4.dp),
                                     modifier = Modifier.weight(1f)
@@ -3260,6 +3276,7 @@ fun FullPlayer(
                                 )
 
                                 // Share Button
+                                val activityContext = LocalContext.current
                                 PlayerActionButton(
                                     icon = Icons.Default.Share,
                                     label = stringResource(R.string.option_share),
@@ -3268,7 +3285,7 @@ fun FullPlayer(
                                             val file = java.io.File(song.path)
                                             if (file.exists()) {
                                                 val contentUri = FileProvider.getUriForFile(
-                                                    context,
+                                                    activityContext,
                                                     "com.demonlab.lune.fileprovider",
                                                     file
                                                 )
@@ -3277,7 +3294,7 @@ fun FullPlayer(
                                                     putExtra(Intent.EXTRA_STREAM, contentUri)
                                                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                                 }
-                                                context.startActivity(Intent.createChooser(shareIntent, context.getString(R.string.option_share)))
+                                                activityContext.startActivity(Intent.createChooser(shareIntent, activityContext.getString(R.string.option_share)))
                                             }
                                         } catch (e: Exception) {
                                             e.printStackTrace()
@@ -3313,6 +3330,48 @@ fun FullPlayer(
                     color = MaterialTheme.colorScheme.primary
                 )
             }
+        }
+
+        if (isLandscape) {
+            Row(
+                modifier = swipeToMinimizeModifier,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        coverContent()
+                    }
+                }
+                Spacer(modifier = Modifier.width(24.dp))
+                Column(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    controlsContent()
+                }
+            }
+        } else {
+            Column(
+                modifier = swipeToMinimizeModifier,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                coverContent()
+                controlsContent()
+            }
+        }
+
+        if (showQueueSheet) {
+            QueueBottomSheet(
+                playbackManager = playbackManager,
+                onDismiss = { showQueueSheet = false }
+            )
         }
 
         if (showQueueSheet) {


### PR DESCRIPTION
## What this PR does

Adds responsive landscape orientation support to the full player screen
and improves the visual quality of cinematic mode.

## Changes

### Landscape layout (`FullPlayer`)
- Detects device orientation using `LocalConfiguration`
- **Portrait**: existing vertical layout is completely unchanged
- **Landscape**: switches to a `Row` layout — album art on the left (50% width),
  playback controls on the right (50% width), both vertically centered
- Reduced top padding in landscape to avoid wasted vertical space

### Cinematic mode background
- Background image now fills the full screen (previously only 60% height)
- Reduced blur from 80dp to 20dp so album colors remain vivid and recognizable
- Replaced the aggressive surface-color gradient with a subtle bottom-only
  gradient for control readability, similar to Apple Music's immersive player
- Normal dark mode background reduced to near-invisible (alpha 0.02) to create
  a clear visual distinction between cinematic ON and cinematic OFF

## Tested on
- Portrait + cinematic OFF ✓
- Portrait + cinematic ON ✓  
- Landscape + cinematic OFF ✓
- Landscape + cinematic ON ✓

## Notes
All Ken Burns animation logic and spin rotation are unchanged.
Only `app/src/main/java/com/demonlab/lune/ui/activities/Lune.kt` is modified.