### PR TITLE
refactor: optimize crossfade transitions, widget updates, and MediaStore bitrate

### DIFF
--- a/.github/workflows/Lune_Build.yml
+++ b/.github/workflows/Lune_Build.yml
@@ -1,4 +1,4 @@
-name: Build Lune Release
+name: Build Lune Debug
 
 on:
   workflow_dispatch:
@@ -17,19 +17,6 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - name: Decode keystore
-        run: |
-          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore.jks
-
-      - name: Create keystore.properties
-        run: |
-          cat <<EOF > keystore.properties
-          storeFile=keystore.jks
-          storePassword=${{ secrets.STORE_PASSWORD }}
-          keyAlias=${{ secrets.KEY_ALIAS }}
-          keyPassword=${{ secrets.KEY_PASSWORD}}
-          EOF
-
       - name: Read versionName
         id: version
         run: |
@@ -40,11 +27,12 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build APK
-        run: ./gradlew assembleRelease
+        # assembleDebug does not require a keystore — Android signs with a test key
+        run: ./gradlew assembleDebug
 
-      - name: Create Github Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: Lune ${{ steps.version.outputs.version }}
-          files: app/build/outputs/apk/release/*apk
+          name: Lune-debug-${{ steps.version.outputs.version }}
+          # Correct path for debug builds
+          path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/Lune_Build.yml
+++ b/.github/workflows/Lune_Build.yml
@@ -1,4 +1,4 @@
-name: Build Lune Debug
+name: Build Lune Release
 
 on:
   workflow_dispatch:
@@ -17,6 +17,19 @@ jobs:
           distribution: temurin
           java-version: 21
 
+      - name: Decode keystore
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore.jks
+
+      - name: Create keystore.properties
+        run: |
+          cat <<EOF > keystore.properties
+          storeFile=keystore.jks
+          storePassword=${{ secrets.STORE_PASSWORD }}
+          keyAlias=${{ secrets.KEY_ALIAS }}
+          keyPassword=${{ secrets.KEY_PASSWORD}}
+          EOF
+
       - name: Read versionName
         id: version
         run: |
@@ -27,12 +40,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build APK
-        # assembleDebug does not require a keystore — Android signs with a test key
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease
 
-      - name: Upload APK
-        uses: actions/upload-artifact@v4
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: Lune-debug-${{ steps.version.outputs.version }}
-          # Correct path for debug builds
-          path: app/build/outputs/apk/debug/*.apk
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Lune ${{ steps.version.outputs.version }}
+          files: app/build/outputs/apk/release/*apk

--- a/app/src/main/java/com/demonlab/lune/tools/MusicProvider.kt
+++ b/app/src/main/java/com/demonlab/lune/tools/MusicProvider.kt
@@ -92,7 +92,7 @@ class MusicProvider(private val context: Context) {
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
         }
 
-        val projection = arrayOf(
+        val projectionList = mutableListOf(
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
             MediaStore.Audio.Media.ARTIST,
@@ -104,9 +104,13 @@ class MusicProvider(private val context: Context) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 MediaStore.Audio.Media.GENRE
             } else {
-                MediaStore.Audio.Media.ARTIST // Safe fallback mapping
+                MediaStore.Audio.Media.ARTIST
             }
         )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            projectionList.add(MediaStore.Audio.Media.BITRATE)
+        }
+        val projection = projectionList.toTypedArray()
 
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
         val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC"
@@ -130,6 +134,9 @@ class MusicProvider(private val context: Context) {
             val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
             val genreColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 cursor.getColumnIndex(MediaStore.Audio.Media.GENRE)
+            } else -1
+            val bitrateColumn = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                cursor.getColumnIndex(MediaStore.Audio.Media.BITRATE)
             } else -1
 
             while (cursor.moveToNext()) {
@@ -172,9 +179,17 @@ class MusicProvider(private val context: Context) {
                     else -> extension.uppercase()
                 }
                 val file = File(data)
-                val bitrate = if (duration > 0 && file.exists()) {
+                
+                val mediaStoreBitrate = if (bitrateColumn != -1) {
+                    val value = cursor.getInt(bitrateColumn)
+                    if (value > 0) value else null
+                } else null
+
+                val calculatedBitrate = if (duration > 0 && file.exists()) {
                     ((file.length() * 8) / (duration / 1000f)).toInt()
                 } else null
+
+                val bitrate = mediaStoreBitrate ?: calculatedBitrate
 
                 val contentUri: Uri = ContentUris.withAppendedId(collection, id)
 

--- a/app/src/main/java/com/demonlab/lune/tools/MusicService.kt
+++ b/app/src/main/java/com/demonlab/lune/tools/MusicService.kt
@@ -441,7 +441,9 @@ class MusicService : MediaBrowserServiceCompat() {
 
     fun crossfadeToSong(song: Song) {
         if (!isCrossfading) {
-            performCrossfade(song)
+            val mp = mediaPlayer
+            val remaining = if (mp != null) (mp.duration - mp.currentPosition).toLong() else 12000L
+            performCrossfade(song, if (remaining in 1..12000L) remaining else 12000L)
         }
     }
 
@@ -455,14 +457,15 @@ class MusicService : MediaBrowserServiceCompat() {
                 if (mp != null && mp.isPlaying && (playbackManager.isCrossfade || playbackManager.isAutomix) && !isCrossfading) {
                     val remaining = mp.duration - mp.currentPosition
                     val duration = mp.duration
-                    val triggerMs = 12000L // 12s per user request (Spotify-style)
+                    val maxTriggerMs = 12000L // Standard transition duration: 12 seconds
 
-                    // Only trigger if we have enough duration and are near the end
-                    if (duration > triggerMs && remaining in 1..triggerMs && mp.currentPosition > (duration / 2)) {
+                    // Only fire if we have enough time left and are nearing the end
+                    if (duration > maxTriggerMs && remaining in 1..maxTriggerMs && mp.currentPosition > (duration / 2)) {
                         val nextSong = playbackManager.getNextSong()
                         if (nextSong != null) {
-                            Log.d("MusicService", "Crossfade triggered for next song: ${nextSong.title}")
-                            performCrossfade(nextSong)
+                            Log.d("MusicService", "Crossfade triggered with duration: $remaining ms")
+                            // We pass the remaining real time as the transition duration
+                            performCrossfade(nextSong, remaining.toLong())
                         }
                     }
                 }
@@ -471,11 +474,10 @@ class MusicService : MediaBrowserServiceCompat() {
         }
     }
 
-    private fun performCrossfade(nextSong: Song) {
+    private fun performCrossfade(nextSong: Song, fadeDurationMs: Long) {
         isCrossfading = true
         val playbackManager = PlaybackManager.getInstance(applicationContext)
         playbackManager.isTransitioning = true
-        val fadeDurationMs = 12000L // 12s per user request
 
         secondaryPlayer?.setOnCompletionListener(null)
         secondaryPlayer?.setOnErrorListener(null)
@@ -490,10 +492,23 @@ class MusicService : MediaBrowserServiceCompat() {
 
         serviceScope.launch {
             try {
+                var prepared = false
                 withContext(Dispatchers.IO) {
-                    secondaryPlayer?.setDataSource(applicationContext, nextSong.uri)
-                    secondaryPlayer?.setVolume(0f, 0f)
-                    secondaryPlayer?.prepare()
+                    try {
+                        secondaryPlayer?.setDataSource(applicationContext, nextSong.uri)
+                        secondaryPlayer?.setVolume(0f, 0f)
+                        secondaryPlayer?.prepare()
+                        prepared = true
+                    } catch (e: Exception) {
+                        Log.e("MusicService", "Failed to prepare secondary player", e)
+                    }
+                }
+
+                if (!prepared) {
+                    isCrossfading = false
+                    playbackManager.isTransitioning = false
+                    playSong(nextSong)
+                    return@launch
                 }
 
                 val sessionId = secondaryPlayer?.audioSessionId ?: 0
@@ -515,6 +530,8 @@ class MusicService : MediaBrowserServiceCompat() {
                 }
 
                 secondaryPlayer?.start()
+                
+                // We ensure proper behavior in the event of premature termination
                 secondaryPlayer?.setOnCompletionListener {
                     if (!isCrossfading) {
                         PlaybackManager.getInstance(applicationContext).playNextFromService(true)
@@ -522,31 +539,22 @@ class MusicService : MediaBrowserServiceCompat() {
                 }
 
                 val steps = 100
-                val interval = fadeDurationMs / steps
-                val isAutomix = PlaybackManager.getInstance(applicationContext).isAutomix
+                val interval = (fadeDurationMs / steps).coerceAtLeast(10L)
 
                 for (i in 1..steps) {
                     if (!isCrossfading) break
 
                     while (!PlaybackManager.getInstance(applicationContext).isPlaying && isCrossfading) {
-                        delay(500)
+                        delay(100)
                     }
                     if (!isCrossfading) break
 
                     val normalizedNext = i.toFloat() / steps
 
-                    val volNext: Float
-                    val volCurrent: Float
-
-                    if (isAutomix) {
-                        val angle = (normalizedNext * Math.PI / 2)
-                        volNext = Math.sin(angle).toFloat()
-                        volCurrent = Math.cos(angle).toFloat()
-                    } else {
-                        volNext = normalizedNext * normalizedNext
-                        val normalizedCurrent = 1f - normalizedNext
-                        volCurrent = normalizedCurrent * normalizedCurrent
-                    }
+                    // Universal constant power curve to avoid volume dips
+                    val angle = (normalizedNext * Math.PI / 2)
+                    val volNext = Math.sin(angle).toFloat()
+                    val volCurrent = Math.cos(angle).toFloat()
 
                     mediaPlayer?.setVolume(volCurrent, volCurrent)
                     secondaryPlayer?.setVolume(volNext, volNext)
@@ -572,6 +580,13 @@ class MusicService : MediaBrowserServiceCompat() {
                 secondaryVirtualizer = null
 
                 mediaPlayer?.setVolume(1f, 1f)
+                
+                // Reconfigure the listener for the promoted player
+                mediaPlayer?.setOnCompletionListener {
+                    if (!isCrossfading) {
+                        PlaybackManager.getInstance(applicationContext).playNextFromService(true)
+                    }
+                }
 
                 withContext(Dispatchers.IO) {
                     oldPlayer?.setOnCompletionListener(null)
@@ -591,6 +606,7 @@ class MusicService : MediaBrowserServiceCompat() {
                 secondaryPlayer?.setOnErrorListener(null)
                 secondaryPlayer?.release()
                 secondaryPlayer = null
+                playSong(nextSong)
             } finally {
                 isCrossfading = false
                 playbackManager.isTransitioning = false
@@ -962,9 +978,10 @@ class MusicService : MediaBrowserServiceCompat() {
 
     private fun startWidgetUpdateTimer() {
         widgetUpdateJob?.cancel()
+        val powerManager = getSystemService(POWER_SERVICE) as android.os.PowerManager
         widgetUpdateJob = serviceScope.launch {
             while (isActive) {
-                if (isPlaying()) {
+                if (isPlaying() && powerManager.isInteractive) {
                     updateWidget()
                 }
                 delay(1000)
@@ -1006,12 +1023,16 @@ class MusicService : MediaBrowserServiceCompat() {
                     val art = fetchAlbumArt(song)
                     if (art != null) {
                         lastSongForRounded = song
-                        cachedRoundedArt = LuneWidgetProvider.getRoundedCornerBitmap(art, 40)
+                        
+                        // Performance fix: We process graphics resources outside the Main Thread
+                        withContext(Dispatchers.IO) {
+                            cachedRoundedArt = LuneWidgetProvider.getRoundedCornerBitmap(art, 40)
 
-                        // Also update blur cache if song changed
-                        if (lastSongForBlur != song) {
-                            lastSongForBlur = song
-                            lastBlurredBitmap = LuneWidgetProvider.getBlurredBitmap(this@MusicService, art, 25, 25)
+                            // Also update blur cache if song changed
+                            if (lastSongForBlur != song) {
+                                lastSongForBlur = song
+                                lastBlurredBitmap = LuneWidgetProvider.getBlurredBitmap(this@MusicService, art, 25, 25)
+                            }
                         }
                     } else {
                         lastSongForRounded = null


### PR DESCRIPTION
Hello! This PR addresses a few performance bottlenecks and stabilizes playback transitions to enhance the overall user experience.

### Key Changes:

1. **Crossfade & AutoMix Stabilization (`MusicService.kt`)**
   - Implemented a **Constant Power (trigonometric sine/cosine)** volume curve for all transitions to eliminate the volume dip at the 50% mark present in quadratic/linear curves.
   - Transitions now calculate remaining duration dynamically, adjusting the fade window if the track is close to the end, preventing silent hangs.
   - Re-configured the promoted player's completion listener safely once the transition completes.

2. **Widget Performance & Battery Optimization (`MusicService.kt`)**
   - Offloaded expensive rounded and blurred bitmap operations from the main thread (`Dispatchers.Main`) to `Dispatchers.IO` in `MusicService` to prevent UI micro-stutters during widget updates.
   - Polling updates are now throttled using `PowerManager.isInteractive` to preserve battery when the device screen is off.

3. **Native Bitrate Query (`MusicProvider.kt`)**
   - Added direct MediaStore querying for the exact encoder bitrate on Android 11+ (API 30+). This solves the issue where files with heavy embedded art skewed the calculated bitrate. It falls back to arithmetic estimation on older SDK versions.

All changes have been tested locally on a physical device, verifying smooth transitions, immediate widget sync upon waking up the device, and accurate bitrate readings. 

Thank you for your time reviewing this!