### PR TITLE
Feature: Custom sleep timer on long press

### DIFF
--- a/app/src/main/java/com/demonlab/lune/tools/PlaybackManager.kt
+++ b/app/src/main/java/com/demonlab/lune/tools/PlaybackManager.kt
@@ -1177,8 +1177,15 @@ class PlaybackManager private constructor(private val context: Context) {
         startSleepTimer()
     }
 
+    fun setCustomSleepTimer(minutes: Int) {
+        sleepTimerMinutes = minutes.coerceAtLeast(0)
+        startSleepTimer()
+    }
+
     private fun startSleepTimer() {
-        sleepTimerHandler?.removeCallbacks(sleepTimerRunnable ?: return)
+        sleepTimerRunnable?.let { runnable ->
+            sleepTimerHandler?.removeCallbacks(runnable)
+        }
         if (sleepTimerMinutes > 0) {
             if (sleepTimerHandler == null) sleepTimerHandler = android.os.Handler(android.os.Looper.getMainLooper())
             sleepTimerRunnable = Runnable {

--- a/app/src/main/java/com/demonlab/lune/ui/components/SharedComponents.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/components/SharedComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -45,8 +46,10 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -625,6 +628,7 @@ fun WaveformVisualizer(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun OptionButton(
     icon: ImageVector,
@@ -632,15 +636,32 @@ fun OptionButton(
     active: Boolean,
     onClick: () -> Unit,
     sublabel: String? = null,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    onLongClick: (() -> Unit)? = null
 ) {
+    val haptic = LocalHapticFeedback.current
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Surface(
-            onClick = onClick,
-            enabled = enabled,
             shape = CircleShape,
             color = if (active) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondaryContainer,
-            modifier = Modifier.size(56.dp).alpha(if (enabled) 1f else 0.5f)
+            modifier = Modifier
+                .size(56.dp)
+                .alpha(if (enabled) 1f else 0.5f)
+                .clip(CircleShape)
+                .then(
+                    if (onLongClick != null) {
+                        Modifier.combinedClickable(
+                            enabled = enabled,
+                            onClick = onClick,
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                onLongClick()
+                            }
+                        )
+                    } else {
+                        Modifier.clickable(enabled = enabled, onClick = onClick)
+                    }
+                )
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(

--- a/app/src/main/java/com/demonlab/lune/ui/sheets/BottomSheets.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/sheets/BottomSheets.kt
@@ -1352,6 +1352,8 @@ fun CustomSleepTimerDialog(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 // Expressive duration badge
+                val offLabel = stringResource(R.string.option_repeat_off)
+                val minUnit = stringResource(R.string.timer_minutes_unit)
                 Surface(
                     shape = RoundedCornerShape(20.dp),
                     color = if (selectedMinutes > 0) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
@@ -1360,13 +1362,13 @@ fun CustomSleepTimerDialog(
                 ) {
                     Text(
                         text = when {
-                            selectedMinutes == 0 -> "Off"
+                            selectedMinutes == 0 -> offLabel
                             selectedMinutes >= 60 -> {
                                 val h = selectedMinutes / 60
                                 val m = selectedMinutes % 60
-                                if (m == 0) "${h}h" else "${h}h ${m}m"
+                                if (m == 0) "${h}h" else "${h}h ${m}${minUnit}"
                             }
-                            else -> "$selectedMinutes min"
+                            else -> "$selectedMinutes $minUnit"
                         },
                         style = MaterialTheme.typography.displaySmall,
                         fontWeight = FontWeight.Bold,
@@ -1390,7 +1392,7 @@ fun CustomSleepTimerDialog(
                             onClick = { selectedMinutes = preset },
                             label = {
                                 Text(
-                                    text = if (preset == 0) "Off" else "${preset}m",
+                                    text = if (preset == 0) offLabel else "${preset}m",
                                     style = MaterialTheme.typography.labelMedium,
                                     fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
                                 )
@@ -1419,7 +1421,7 @@ fun CustomSleepTimerDialog(
                         modifier = Modifier.size(44.dp),
                         shape = CircleShape
                     ) {
-                        Icon(Icons.Default.Remove, contentDescription = "Decrease 5 min")
+                        Icon(Icons.Default.Remove, contentDescription = stringResource(R.string.cd_timer_decrease))
                     }
 
                     Slider(
@@ -1443,7 +1445,7 @@ fun CustomSleepTimerDialog(
                         modifier = Modifier.size(44.dp),
                         shape = CircleShape
                     ) {
-                        Icon(Icons.Default.Add, contentDescription = "Increase 5 min")
+                        Icon(Icons.Default.Add, contentDescription = stringResource(R.string.cd_timer_increase))
                     }
                 }
             }
@@ -1461,7 +1463,7 @@ fun CustomSleepTimerDialog(
                 )
             ) {
                 Text(
-                    text = if (selectedMinutes == 0) "Turn Off" else "Set Timer",
+                    text = if (selectedMinutes == 0) stringResource(R.string.timer_turn_off) else stringResource(R.string.timer_set),
                     fontWeight = FontWeight.SemiBold
                 )
             }

--- a/app/src/main/java/com/demonlab/lune/ui/sheets/BottomSheets.kt
+++ b/app/src/main/java/com/demonlab/lune/ui/sheets/BottomSheets.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -928,6 +929,17 @@ fun PlayerOptionsBottomSheet(
         dragHandle = { BottomSheetDefaults.DragHandle() }
     ) {
         val isFavorite = playbackManager.currentSong?.isFavorite == true
+        var showCustomTimerDialog by remember { mutableStateOf(false) }
+
+        if (showCustomTimerDialog) {
+            CustomSleepTimerDialog(
+                currentMinutes = playbackManager.sleepTimerMinutes,
+                onDismiss = { showCustomTimerDialog = false },
+                onSetTimer = { minutes ->
+                    playbackManager.setCustomSleepTimer(minutes)
+                }
+            )
+        }
 
         Column(
             modifier = Modifier
@@ -1017,7 +1029,8 @@ fun PlayerOptionsBottomSheet(
                         icon = Icons.Default.Timer,
                         label = if (playbackManager.sleepTimerMinutes > 0) "${playbackManager.sleepTimerMinutes}m" else stringResource(R.string.option_timer),
                         active = playbackManager.sleepTimerMinutes > 0,
-                        onClick = { playbackManager.toggleSleepTimer() }
+                        onClick = { playbackManager.toggleSleepTimer() },
+                        onLongClick = { showCustomTimerDialog = true }
                     )
                 }
 
@@ -1292,3 +1305,175 @@ fun EditSongBottomSheet(
         }
     }
 }
+
+@Composable
+fun CustomSleepTimerDialog(
+    currentMinutes: Int,
+    onDismiss: () -> Unit,
+    onSetTimer: (Int) -> Unit
+) {
+    var selectedMinutes by remember {
+        mutableStateOf(if (currentMinutes > 0) currentMinutes else 30)
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(28.dp),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+        icon = {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                modifier = Modifier.size(52.dp)
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Default.Bedtime,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(26.dp)
+                    )
+                }
+            }
+        },
+        title = {
+            Text(
+                text = stringResource(R.string.option_timer),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // Expressive duration badge
+                Surface(
+                    shape = RoundedCornerShape(20.dp),
+                    color = if (selectedMinutes > 0) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f)
+                    else MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                ) {
+                    Text(
+                        text = when {
+                            selectedMinutes == 0 -> "Off"
+                            selectedMinutes >= 60 -> {
+                                val h = selectedMinutes / 60
+                                val m = selectedMinutes % 60
+                                if (m == 0) "${h}h" else "${h}h ${m}m"
+                            }
+                            else -> "$selectedMinutes min"
+                        },
+                        style = MaterialTheme.typography.displaySmall,
+                        fontWeight = FontWeight.Bold,
+                        color = if (selectedMinutes > 0) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+
+                // Quick preset chips row
+                val presets = listOf(0, 15, 30, 45, 60, 90, 120)
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(horizontal = 2.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    items(presets) { preset ->
+                        val isSelected = selectedMinutes == preset
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = { selectedMinutes = preset },
+                            label = {
+                                Text(
+                                    text = if (preset == 0) "Off" else "${preset}m",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                                )
+                            },
+                            shape = RoundedCornerShape(12.dp),
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                                containerColor = MaterialTheme.colorScheme.surfaceContainer
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // Stepper + Slider
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    FilledTonalIconButton(
+                        onClick = { selectedMinutes = (selectedMinutes - 5).coerceAtLeast(0) },
+                        enabled = selectedMinutes > 0,
+                        modifier = Modifier.size(44.dp),
+                        shape = CircleShape
+                    ) {
+                        Icon(Icons.Default.Remove, contentDescription = "Decrease 5 min")
+                    }
+
+                    Slider(
+                        value = selectedMinutes.toFloat(),
+                        onValueChange = { selectedMinutes = ((it / 5).roundToInt() * 5) },
+                        valueRange = 0f..180f,
+                        steps = 35,
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 12.dp),
+                        colors = SliderDefaults.colors(
+                            thumbColor = MaterialTheme.colorScheme.primary,
+                            activeTrackColor = MaterialTheme.colorScheme.primary,
+                            inactiveTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        )
+                    )
+
+                    FilledTonalIconButton(
+                        onClick = { selectedMinutes = (selectedMinutes + 5).coerceAtMost(180) },
+                        enabled = selectedMinutes < 180,
+                        modifier = Modifier.size(44.dp),
+                        shape = CircleShape
+                    ) {
+                        Icon(Icons.Default.Add, contentDescription = "Increase 5 min")
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSetTimer(selectedMinutes)
+                    onDismiss()
+                },
+                shape = RoundedCornerShape(16.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text(
+                    text = if (selectedMinutes == 0) "Turn Off" else "Set Timer",
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}
+

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -77,6 +77,11 @@
     <string name="option_crossfade">Crossfade</string>
     <string name="option_automix">Automix</string>
     <string name="option_timer">Timer</string>
+    <string name="timer_set">Timer stellen</string>
+    <string name="timer_turn_off">Ausschalten</string>
+    <string name="timer_minutes_unit">Min.</string>
+    <string name="cd_timer_decrease">5 Minuten verringern</string>
+    <string name="cd_timer_increase">5 Minuten erhöhen</string>
     <string name="option_lyrics">Liedtext</string>
     <string name="transition_mixing">Mischen</string>
     <string name="transition_crossfade">Crossfade</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -77,6 +77,11 @@
     <string name="option_crossfade">Transición</string>
     <string name="option_automix">Mezcla automática</string>
     <string name="option_timer">Temporizador</string>
+    <string name="timer_set">Establecer</string>
+    <string name="timer_turn_off">Desactivar</string>
+    <string name="timer_minutes_unit">min</string>
+    <string name="cd_timer_decrease">Disminuir 5 minutos</string>
+    <string name="cd_timer_increase">Aumentar 5 minutos</string>
     <string name="option_lyrics">Letras</string>
     <string name="transition_mixing">Mezclando</string>
     <string name="transition_crossfade">Transición</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -79,6 +79,11 @@
     <string name="option_crossfade">هکراس‌فید</string>
     <string name="option_automix">میکس خودکار</string>
     <string name="option_timer">زمان‌سنج</string>
+    <string name="timer_set">تنظیم زمان‌سنج</string>
+    <string name="timer_turn_off">خاموش کردن</string>
+    <string name="timer_minutes_unit">دقیقه</string>
+    <string name="cd_timer_decrease">کاهش ۵ دقیقه</string>
+    <string name="cd_timer_increase">افزایش ۵ دقیقه</string>
     <string name="option_lyrics">متن آهنگ</string>
     <string name="transition_mixing">میکس کردن</string>
     <string name="transition_crossfade">کراس‌فید</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -77,6 +77,11 @@
     <string name="option_crossfade">Fondu enchaîné</string>
     <string name="option_automix">Automix</string>
     <string name="option_timer">Minuteur</string>
+    <string name="timer_set">Régler</string>
+    <string name="timer_turn_off">Désactiver</string>
+    <string name="timer_minutes_unit">min</string>
+    <string name="cd_timer_decrease">Diminuer de 5 minutes</string>
+    <string name="cd_timer_increase">Augmenter de 5 minutes</string>
     <string name="option_lyrics">Paroles</string>
     <string name="transition_mixing">Mixage</string>
     <string name="transition_crossfade">Fondu enchaîné</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -77,6 +77,11 @@
     <string name="option_crossfade">Crossfade</string>
     <string name="option_automix">Automix</string>
     <string name="option_timer">Temporizador</string>
+    <string name="timer_set">Definir</string>
+    <string name="timer_turn_off">Desativar</string>
+    <string name="timer_minutes_unit">min</string>
+    <string name="cd_timer_decrease">Diminuir 5 minutos</string>
+    <string name="cd_timer_increase">Aumentar 5 minutos</string>
     <string name="option_lyrics">Letras</string>
     <string name="transition_mixing">Misturando</string>
     <string name="transition_crossfade">Crossfade</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -80,6 +80,11 @@
     <string name="option_crossfade">Кроссфейд</string>
     <string name="option_automix">Автомикс</string>
     <string name="option_timer">Таймер</string>
+    <string name="timer_set">Установить</string>
+    <string name="timer_turn_off">Выключить</string>
+    <string name="timer_minutes_unit">мин</string>
+    <string name="cd_timer_decrease">Уменьшить на 5 минут</string>
+    <string name="cd_timer_increase">Увеличить на 5 минут</string>
     <string name="option_lyrics">Текст песни</string>
     <string name="transition_mixing">Микширование</string>
     <string name="transition_crossfade">Кроссфейд</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -77,6 +77,11 @@
     <string name="option_crossfade">交叉淡化</string>
     <string name="option_automix">自动混音</string>
     <string name="option_timer">定时器</string>
+    <string name="timer_set">设置定时器</string>
+    <string name="timer_turn_off">关闭</string>
+    <string name="timer_minutes_unit">分钟</string>
+    <string name="cd_timer_decrease">减少5分钟</string>
+    <string name="cd_timer_increase">增加5分钟</string>
     <string name="option_lyrics">歌词</string>
     <string name="transition_mixing">混音</string>
     <string name="transition_crossfade">交叉淡化</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,11 @@
     <string name="option_crossfade">Crossfade</string>
     <string name="option_automix">Automix</string>
     <string name="option_timer">Timer</string>
+    <string name="timer_set">Set Timer</string>
+    <string name="timer_turn_off">Turn Off</string>
+    <string name="timer_minutes_unit">min</string>
+    <string name="cd_timer_decrease">Decrease 5 minutes</string>
+    <string name="cd_timer_increase">Increase 5 minutes</string>
     <string name="option_lyrics">Lyrics</string>
     <string name="transition_mixing">Mixing</string>
     <string name="transition_crossfade">Crossfade</string>


### PR DESCRIPTION
I've been using Lune for a few months and love the app. The only limitation I ran into was the sleep timer maxing out at 60 minutes. Because it usually takes me a couple of hours to fall asleep, 60 minutes simply is not enough. I added this feature to allow the user to choose any custom duration up to 3 hours.

The original single-tap functionality remains completely untouched. Tapping the timer button continues to toggle through the standard presets (Off, 15m, 30m, 60m, Off) exactly as before.

Holding down the Timer button now triggers a light haptic vibration and opens a modal dialog. Inside the dialog, users can choose from quick preset chips (Off, 15m, 30m, 45m, 60m, 90m, 120m), adjust the duration using plus/minus five-minute stepper buttons, or drag the slider ranging from 0 to 180 minutes. The dialog displays the selected time and includes standard Set Timer, Turn Off, and Cancel actions.

Added translations for the 7 other supported languages via Google Translate.

https://github.com/user-attachments/assets/2c4d0705-b024-43ed-b8b7-c0ce2a635cc1


