### PR TITLE
Add CI workflow for pull request verification

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,38 @@
+name: PR Verification
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'src/**'
+      - '**/*.gradle*'
+      - 'gradle/**'
+      - '**/*.toml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest --no-daemon


### PR DESCRIPTION
Adds a lightweight CI workflow to automatically run unit tests and verify builds on PRs. It triggers only on relevant code/gradle changes and cancels outdated runs to save runner minutes. Helps catch regressions early before merging.